### PR TITLE
Revamp portfolio projects and contact information

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,124 +1,232 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio - Nguyen Pham Minh Tri</title>
-    <link rel="icon" type="image/png" href="assets/profile_anime.webp">
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+    <link rel="icon" type="image/png" href="assets/profile_anime.webp" />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+    />
     <script defer src="script.js"></script>
-    <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
-</head>
-<body>
+    <script
+      src="https://kit.fontawesome.com/a076d05399.js"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
     <header>
-        <nav>
-            <div class="logo">MinTrees</div>
-            <ul class="nav-links">
-                <li><a href="#home">Home</a></li>
-                <li><a href="#about">About</a></li>
-                <li><a href="#skills">Technical Skills</a></li>
-                <li><a href="#projects">Projects</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-        </nav>
+      <nav>
+        <div class="logo">MinTrees</div>
+        <ul class="nav-links">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#skills">Technical Skills</a></li>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
     </header>
-    
 
     <!-- Hero Section -->
     <section class="hero" id="home">
-        <div class="content">
-            <h3>Hello, I'm</h3>
-            <h1>Nguyen Pham Minh Tri</h1>
-            <h2>Backend Developer | Java & Spring Boot </h2>
-            <p>
-                A passionate backend developer specializing in Java, Spring Boot, and microservices. 
-                I focus on designing scalable, secure, and efficient backend systems.
-            </p>
-            <div class="social-icons">
-                <a href="https://linkedin.com/in/mintrees-backend" target="_blank"><i class="fab fa-linkedin"></i></a>
-                <a href="https://github.com/Min-Trees" target="_blank"><i class="fab fa-github"></i></a>
-            </div>
-            <a href="assets/NguyenPhamMinhTri_CVBE.pdf" class="btn" download>Download CV</a>
+      <div class="content">
+        <h3>Hello, I'm</h3>
+        <h1>Nguyen Pham Minh Tri</h1>
+        <h2>Backend Developer | Java 17 & Spring Boot</h2>
+        <p>
+          Backend developer with hands-on experience building secure and
+          scalable microservices using Java 17 and the Spring ecosystem.
+        </p>
+        <div class="social-icons">
+          <a href="https://linkedin.com/in/mintrees-backend" target="_blank"
+            ><i class="fab fa-linkedin"></i
+          ></a>
+          <a href="https://github.com/dev-java-minhtri" target="_blank"
+            ><i class="fab fa-github"></i
+          ></a>
         </div>
-        <div class="image">
-            <img src="assets/profile.jpg" alt="Nguyen Pham Minh Tri">
-        </div>
-        
+        <a href="assets/NguyenPhamMinhTri_CVBE.pdf" class="btn" download
+          >Download CV</a
+        >
+      </div>
+      <div class="image">
+        <img src="assets/profile.jpg" alt="Nguyen Pham Minh Tri" />
+      </div>
     </section>
 
     <!-- About Me -->
     <section id="about">
-        <h2>About Me</h2>
-        <p>
-            I am a third-year Information Technology student at Thu Dau Mot University. 
-            With a solid foundation in backend development, I specialize in Java and the Spring ecosystem.
-            My goal is to create scalable and secure applications while continuously learning and adapting to new technologies.
-        </p>
+      <h2>About Me</h2>
+      <p>
+        I am a third-year Information Technology student at Thu Dau Mot
+        University. With a solid foundation in backend development, I specialize
+        in Java and the Spring ecosystem. My goal is to create scalable and
+        secure applications while continuously learning and adapting to new
+        technologies.
+      </p>
     </section>
 
     <!-- Skills Section -->
     <section id="skills">
-        <h2>Technical Skills</h2>
-        <div class="skills-container">
-            <div class="skill-card"><img src="assets/java.png" alt="Java"><p>Java</p></div>
-            <div class="skill-card"><img src="assets/python.webp" alt="Python"><p>Python</p></div>
-            <div class="skill-card"><img src="assets/cpp.png" alt="C++"><p>C++</p></div>
-            <div class="skill-card"><img src="assets/springboot.jpg" alt="PostgreSQL"><p>Springboot</p></div>
-            <div class="skill-card"><img src="assets/diango.png" alt="Django"><p>Django</p></div>
-            <div class="skill-card"><img src="assets/rabbitmq.png" alt="RabbitMQ"><p>RabbitMQ</p></div>
-            <div class="skill-card"><img src="assets/docker.png" alt="Docker"><p>Docker</p></div>
-            <div class="skill-card"><img src="assets/sqlServer.png" alt="SQL Server"><p>SQL Server</p></div>
-            <div class="skill-card"><img src="assets/postgresql.png" alt="PostgreSQL"><p>PostgreSQL</p></div>
-            <div class="skill-card"><img src="assets/intelij.jpg" alt="intelij"><p>Intelij</p></div>
-            <div class="skill-card"><img src="assets/vscode.jpg" alt="VS Code"><p>VS Code</p></div>
-            <div class="skill-card"><img src="assets/postman.jpg" alt="Postman"><p>Postman</p></div>
-            <div class="skill-card"><img src="assets/trello.jpg" alt="trello"><p>Trello</p></div>
-            <div class="skill-card"><img src="assets/git.png" alt="Git"><p>Git</p></div>
-            <div class="skill-card"><img src="assets/github.png" alt="GitHub"><p>GitHub</p></div>
-            <div class="skill-card"><img src="assets/client-server.png" alt="client-server"><p>Client-server</p></div>
-            <div class="skill-card"><img src="assets/microservice.png" alt="Microservices"><p>Microservices</p></div>
-            
+      <h2>Technical Skills</h2>
+      <div class="skills-container">
+        <div class="skill-card">
+          <img src="assets/java.png" alt="Java" />
+          <p>Java</p>
         </div>
+        <div class="skill-card">
+          <img src="assets/python.webp" alt="Python" />
+          <p>Python</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/cpp.png" alt="C++" />
+          <p>C++</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/springboot.jpg" alt="PostgreSQL" />
+          <p>Springboot</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/diango.png" alt="Django" />
+          <p>Django</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/rabbitmq.png" alt="RabbitMQ" />
+          <p>RabbitMQ</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/docker.png" alt="Docker" />
+          <p>Docker</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/sqlServer.png" alt="SQL Server" />
+          <p>SQL Server</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/postgresql.png" alt="PostgreSQL" />
+          <p>PostgreSQL</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/intelij.jpg" alt="intelij" />
+          <p>Intelij</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/vscode.jpg" alt="VS Code" />
+          <p>VS Code</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/postman.jpg" alt="Postman" />
+          <p>Postman</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/trello.jpg" alt="trello" />
+          <p>Trello</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/git.png" alt="Git" />
+          <p>Git</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/github.png" alt="GitHub" />
+          <p>GitHub</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/client-server.png" alt="client-server" />
+          <p>Client-server</p>
+        </div>
+        <div class="skill-card">
+          <img src="assets/microservice.png" alt="Microservices" />
+          <p>Microservices</p>
+        </div>
+      </div>
     </section>
 
     <!-- Projects Section -->
     <section id="projects">
-        <h2>My Projects</h2>
-        <div class="project-container">
-            <div class="project-card">
-                <h3>Auction Website</h3>
-                <p><strong>Description:</strong> A real-time online auction platform where users can bid on products securely.</p>
-                <p><strong>Technologies:</strong> Spring Boot, React, SQL Server, RabbitMQ, Docker</p>
-                <p><strong>Responsibilities:</strong></p>
-                <ul>
-                    <li>Designed backend architecture using Spring Boot and microservices.</li>
-                    <li>Implemented user authentication and real-time bid processing with RabbitMQ.</li>
-                    <li>Developed RESTful APIs for frontend integration.</li>
-                </ul>
-                <a href="https://github.com/Min-Trees/Auction_MockProject" target="_blank" class="btn">View Project</a>
-            </div>
-    
-            <div class="project-card">
-                <h3>Toomeet Social Media</h3>
-                <p><strong>Description:</strong> A student-focused social networking platform with real-time chat.</p>
-                <p><strong>Technologies:</strong> Spring Boot, Microservices, PostgreSQL, WebSocket</p>
-                <p><strong>Responsibilities:</strong></p>
-                <ul>
-                    <li>Developed Group Service for managing communities.</li>
-                    <li>Implemented WebSocket for instant messaging.</li>
-                    <li>Optimized database performance for handling large-scale interactions.</li>
-                </ul>
-                <a href="https://github.com/Min-Trees/TooMeet" target="_blank" class="btn">View Project</a>
-            </div>
+      <h2>My Projects</h2>
+      <div class="project-container">
+        <div class="project-card">
+          <h3>ABC-ENGLISH – Online English Learning Platform</h3>
+          <p>
+            <strong>Description:</strong> RESTful API for an English learning
+            platform featuring email verification, role-based access, grammar
+            checking, AI writing evaluation and secure VNPay payments.
+          </p>
+          <p>
+            <strong>Technologies:</strong> Java 17, Spring Boot 3.3.3,
+            PostgreSQL, Redis, Docker, Springdoc OpenAPI, MapStruct,
+            LanguageTool, Google Gemma API, VNPay
+          </p>
+          <p><strong>Responsibilities:</strong></p>
+          <ul>
+            <li>Designed system architecture and database schema.</li>
+            <li>Implemented secure APIs with JWT and OAuth2.</li>
+            <li>Integrated AI services and VNPay payment gateway.</li>
+            <li>Optimized performance using Redis and Docker.</li>
+            <li>Documented APIs with Swagger/OpenAPI.</li>
+          </ul>
+          <a
+            href="https://github.com/dev-java-minhtri"
+            target="_blank"
+            class="btn"
+            >View Project</a
+          >
         </div>
+
+        <div class="project-card">
+          <h3>Auction – Online Auction Website</h3>
+          <p>
+            <strong>Description:</strong> U.S.-based online auction platform for
+            item listing, bidding and real-time goods exchange.
+          </p>
+          <p>
+            <strong>Technologies:</strong> ReactJS, Tailwind CSS, TypeScript,
+            Spring Boot, Spring Security, Spring Cloud, RabbitMQ, JWT, OAuth2,
+            SQL Server, Docker, Swagger
+          </p>
+          <p><strong>Responsibilities:</strong></p>
+          <ul>
+            <li>
+              Chose backend technologies and designed system architecture and
+              database.
+            </li>
+            <li>
+              Developed core APIs for authentication, authorization, auction
+              CRUD and participation.
+            </li>
+            <li>
+              Reviewed code, resolved backend issues and collaborated with PO &
+              BA on roadmap.
+            </li>
+            <li>Worked within Agile-Scrum alongside a 14-member team.</li>
+          </ul>
+          <a
+            href="https://github.com/dev-java-minhtri"
+            target="_blank"
+            class="btn"
+            >View Project</a
+          >
+        </div>
+      </div>
     </section>
-    
+
     <!-- Contact Section -->
     <section id="contact">
-        <h2>Contact Me</h2>
-        <p>Email: <a href="mailto:npminhtri.be@gmail.com">npminhtri.be@gmail.com</a></p>
-        <p>Phone: +84 393692134</p>
+      <h2>Contact Me</h2>
+      <p>
+        Email:
+        <a href="mailto:npminhtri.be@gmail.com">npminhtri.be@gmail.com</a>
+      </p>
+      <p>Zalo: <a href="https://zalo.me/0393692134">0393692134</a></p>
+      <p>
+        LinkedIn:
+        <a href="https://linkedin.com/in/mintrees-backend" target="_blank"
+          >linkedin.com/in/mintrees-backend</a
+        >
+      </p>
     </section>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Modernize hero section to highlight Java 17 & Spring Boot and link to updated GitHub profile
- Replace projects with ABC-ENGLISH and Auction case studies
- Expand contact section with Zalo and LinkedIn links

## Testing
- `npx prettier --check index.html`

------
https://chatgpt.com/codex/tasks/task_e_689c57211f2c832ea10839e7691ecd22